### PR TITLE
feat: track bottom sheet index and dynamic height

### DIFF
--- a/App.js
+++ b/App.js
@@ -139,8 +139,16 @@ function AppInner() {
   // cluster radius v pixelech – čím víc přiblíženo, tím menší radius
   const clusterRadiusPx = useClusterRadiusPx(region);
 
+  const snapPoints = useMemo(() => ['14%', '50%', '90%'], []);
+  const setIsExpanded = useCallback((expanded) => {
+    setSheetIndex(expanded ? 1 : 0);
+  }, []);
+  const isExpanded = sheetIndex > 0;
+  const isHalfExpanded = sheetIndex === 1;
+  const isFullyExpanded = sheetIndex === 2;
+
   // BottomSheet layout state
-  const { isExpanded, setIsExpanded, sheetH, sheetTopH, setSheetTopH, sheetTop } = useBottomSheet({
+  const { sheetTopH, setSheetTopH, sheetTop } = useBottomSheet({
     onAtTargetHeight: () => {
       if (pendingFocusCoordRef.current) {
         const coord = pendingFocusCoordRef.current;
@@ -157,8 +165,8 @@ function AppInner() {
         });
       }
     },
-    collapsedH: 110,
-    expandedMaxH: Math.min(420, SCREEN_H * 0.6),
+    snapPoints,
+    sheetIndex,
   });
 
   // Visible centering utilities (extract from hook)
@@ -300,10 +308,9 @@ function AppInner() {
         P={P}
         isDark={isDark}
         t={t}
-        sheetH={sheetH}
+        snapPoints={snapPoints}
+        sheetIndex={sheetIndex}
         setSheetTopH={setSheetTopH}
-        isExpanded={isExpanded}
-        setIsExpanded={setIsExpanded}
         filteredPlaces={filteredPlaces}
         places={places}
         radiusM={radiusM}

--- a/src/components/BottomSheetPanel.jsx
+++ b/src/components/BottomSheetPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useEffect, useCallback } from 'react';
+import React, { useRef, useEffect, useCallback, useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import * as Haptics from 'expo-haptics';
 import BottomSheet, { BottomSheetFlatList } from '@gorhom/bottom-sheet';
@@ -12,10 +12,9 @@ export default function BottomSheetPanel({
   P,
   isDark,
   t,
-  sheetH,
+  snapPoints,
+  sheetIndex,
   setSheetTopH,
-  isExpanded,
-  setIsExpanded,
   filteredPlaces,
   places,
   radiusM,
@@ -36,7 +35,9 @@ export default function BottomSheetPanel({
 }) {
   const insets = useSafeAreaInsets();
   const sheetRef = useRef(null);
-  const snapPoints = useMemo(() => ['14%', '50%', '90%'], []);
+  const [localIndex, setLocalIndex] = useState(sheetIndex || 0);
+  const isHalfExpanded = localIndex === 1;
+  const isFullyExpanded = localIndex === 2;
 
   // DEBUG: mount/unmount + render počitadlo
   useEffect(() => {
@@ -48,23 +49,19 @@ export default function BottomSheetPanel({
   const lastIndexRef = useRef(-1);
   useEffect(() => {
     if (!sheetRef.current) return;
-    const target = isExpanded ? 1 : 0;
-    if (lastIndexRef.current === target) return; // už jsme tam
-    lastIndexRef.current = target;
-    try { sheetRef.current.snapToIndex(target); } catch {}
-  }, [isExpanded]);
+    if (lastIndexRef.current === sheetIndex) return;
+    lastIndexRef.current = sheetIndex;
+    try { sheetRef.current.snapToIndex(sheetIndex); } catch {}
+    setLocalIndex(sheetIndex);
+  }, [sheetIndex]);
 
   const handleSheetChange = useCallback(
     (index) => {
-      const expanded = index > 0;
-      // nastav jen když se opravdu liší → nevyvolávej smyčku
-      if (expanded !== isExpanded) {
-        setIsExpanded?.(expanded);
-        try { Haptics.selectionAsync(); } catch {}
-        onSheetIndexChange?.(index);
-      }
+      setLocalIndex(index);
+      try { Haptics.selectionAsync(); } catch {}
+      onSheetIndexChange?.(index);
     },
-    [isExpanded, setIsExpanded, onSheetIndexChange]
+    [onSheetIndexChange]
   );
 
   const topBarHRef = useRef(-1);
@@ -141,7 +138,7 @@ export default function BottomSheetPanel({
     <View style={StyleSheet.absoluteFillObject} pointerEvents="box-none">
       <BottomSheet
         ref={sheetRef}
-        index={0}
+        index={sheetIndex}
         snapPoints={snapPoints}
         enablePanDownToClose={false}
         onChange={handleSheetChange}

--- a/src/hooks/useBottomSheet.js
+++ b/src/hooks/useBottomSheet.js
@@ -1,39 +1,29 @@
-import { useEffect, useRef, useState } from 'react';
-import { Animated, Dimensions } from 'react-native';
+import { useEffect, useState } from 'react';
+import { Dimensions } from 'react-native';
 
 const { height: SCREEN_H } = Dimensions.get('window');
 
-export function useBottomSheet({
-  onAtTargetHeight,
-  collapsedH = 110,
-  expandedMaxH = Math.min(420, SCREEN_H * 0.6),
-}) {
-  const [isExpanded, setIsExpanded] = useState(false);
+const resolveSnapPoint = (sp) => {
+  if (typeof sp === 'number') return sp;
+  if (typeof sp === 'string' && sp.trim().endsWith('%')) {
+    const pct = parseFloat(sp) / 100;
+    if (!Number.isNaN(pct)) return SCREEN_H * pct;
+  }
+  return 0;
+};
+
+export function useBottomSheet({ onAtTargetHeight, snapPoints = [], sheetIndex = 0 }) {
   const [sheetTopH, setSheetTopH] = useState(0);
-  const [sheetTop, setSheetTop] = useState(SCREEN_H - collapsedH);
-  const sheetH = useRef(new Animated.Value(collapsedH)).current;
+  const [sheetTop, setSheetTop] = useState(
+    SCREEN_H - resolveSnapPoint(snapPoints[sheetIndex] ?? 0),
+  );
 
   useEffect(() => {
-    Animated.spring(sheetH, {
-      toValue: isExpanded ? expandedMaxH : collapsedH,
-      useNativeDriver: false,
-      friction: 9,
-      tension: 80,
-    }).start();
-  }, [isExpanded, sheetH, collapsedH, expandedMaxH]);
+    const h = resolveSnapPoint(snapPoints[sheetIndex] ?? 0);
+    setSheetTop(SCREEN_H - h);
+    onAtTargetHeight?.();
+  }, [snapPoints, sheetIndex, onAtTargetHeight]);
 
-  useEffect(() => {
-    const id = sheetH.addListener(({ value }) => {
-      setSheetTop(SCREEN_H - value);
-      const targetH = isExpanded ? expandedMaxH : collapsedH;
-      if (Math.abs(value - targetH) < 0.5) {
-        onAtTargetHeight?.();
-      }
-    });
-    return () => { sheetH.removeListener(id); };
-  }, [sheetH, isExpanded, collapsedH, expandedMaxH, onAtTargetHeight]);
-
-  return { isExpanded, setIsExpanded, sheetH, sheetTopH, setSheetTopH, sheetTop };
+  return { sheetTopH, setSheetTopH, sheetTop };
 }
-
 


### PR DESCRIPTION
## Summary
- add `sheetIndex` with derived expansion flags and configurable snap points
- update BottomSheetPanel to sync with `sheetIndex`
- compute bottom sheet top from current snap point

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ea5939d1083228c59c90f33a9cc3f