### PR TITLE
fix: stabilize bottom sheet and expose radius chips

### DIFF
--- a/App.js
+++ b/App.js
@@ -82,6 +82,9 @@ function AppInner() {
 
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [sheetIndex, setSheetIndex] = useState(0);
+  const handleSheetIndexChange = useCallback((index) => {
+    setSheetIndex((prev) => (prev === index ? prev : index));
+  }, []);
 
   const { hasPermission, region, setRegion, coords, followMe, setFollowMe, disableFollow, recenter } = useLocationFollow({
     animateToRegionSafe,
@@ -327,7 +330,7 @@ function AppInner() {
         onNavigatePreferred={onNavigatePreferred}
         openNavigation={openNavigation}
         focusPlace={focusPlace}
-        onSheetIndexChange={setSheetIndex}
+        onSheetIndexChange={handleSheetIndexChange}
       />
 
       <SearchControls

--- a/src/components/BottomSheetPanel.jsx
+++ b/src/components/BottomSheetPanel.jsx
@@ -46,22 +46,22 @@ export default function BottomSheetPanel({
   }, []);
   console.count('BottomSheetPanel render');
 
-  const lastIndexRef = useRef(-1);
   useEffect(() => {
     if (!sheetRef.current) return;
-    if (lastIndexRef.current === sheetIndex) return;
-    lastIndexRef.current = sheetIndex;
+    if (sheetIndex === localIndex) return;
     try { sheetRef.current.snapToIndex(sheetIndex); } catch {}
     setLocalIndex(sheetIndex);
-  }, [sheetIndex]);
+  }, [sheetIndex, localIndex]);
 
   const handleSheetChange = useCallback(
     (index) => {
       setLocalIndex(index);
       try { Haptics.selectionAsync(); } catch {}
-      onSheetIndexChange?.(index);
+      if (index !== sheetIndex) {
+        onSheetIndexChange?.(index);
+      }
     },
-    [onSheetIndexChange]
+    [onSheetIndexChange, sheetIndex]
   );
 
   const topBarHRef = useRef(-1);
@@ -141,6 +141,7 @@ export default function BottomSheetPanel({
         index={sheetIndex}
         snapPoints={snapPoints}
         enablePanDownToClose={false}
+        enableOverDrag={false}
         onChange={handleSheetChange}
         style={{ zIndex: 0 }}
         backgroundStyle={{

--- a/src/components/SearchControls.jsx
+++ b/src/components/SearchControls.jsx
@@ -67,6 +67,6 @@ const stylesRoot = StyleSheet.create({
     right: 0,
     bottom: 0,
     left: 0,
-    zIndex: 1000,
+    zIndex: 1100,
   },
 });

--- a/src/styles/appStyles.js
+++ b/src/styles/appStyles.js
@@ -99,7 +99,15 @@ export const appStyles = StyleSheet.create({
   clusterWrap: { minWidth: 34, height: 34, paddingHorizontal: 6, borderRadius: 17, alignItems: 'center', justifyContent: 'center', backgroundColor: '#111', borderWidth: 3, borderColor: '#fff', shadowColor: '#000', shadowOpacity: 0.25, shadowRadius: 6, shadowOffset: { width: 0, height: 2 } },
   clusterText: { color: '#fff', fontSize: 13, fontWeight: '900' },
 
-  quickChipsWrap: { position: 'absolute', right: 10, top: SCREEN_H * 0.28, gap: 8, zIndex: 6, alignItems: 'flex-end' },
+  quickChipsWrap: {
+    position: 'absolute',
+    right: 10,
+    top: SCREEN_H * 0.28,
+    gap: 8,
+    zIndex: 1100,
+    elevation: 12,
+    alignItems: 'flex-end',
+  },
   quickChip: { backgroundColor: '#0F172A', paddingHorizontal: 10, paddingVertical: 8, borderRadius: 12 },
   quickChipActive: { backgroundColor: '#111' },
   quickChipTxt: { color: '#fff', fontSize: 12, fontWeight: '800' },


### PR DESCRIPTION
## Summary
- prevent over-drag on bottom sheet and avoid index resets during gestures
- raise search controls z-layer so quick radius chips stay visible

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689eadb666d08322a145bb73d6f5b53b