### PR TITLE
refactor bottom sheet index handling

### DIFF
--- a/src/components/BottomSheetPanel.jsx
+++ b/src/components/BottomSheetPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useCallback, useState } from 'react';
+import React, { useRef, useEffect, useCallback } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import * as Haptics from 'expo-haptics';
 import BottomSheet, { BottomSheetFlatList } from '@gorhom/bottom-sheet';
@@ -35,9 +35,6 @@ export default function BottomSheetPanel({
 }) {
   const insets = useSafeAreaInsets();
   const sheetRef = useRef(null);
-  const [localIndex, setLocalIndex] = useState(sheetIndex || 0);
-  const isHalfExpanded = localIndex === 1;
-  const isFullyExpanded = localIndex === 2;
 
   // DEBUG: mount/unmount + render počitadlo
   useEffect(() => {
@@ -46,22 +43,12 @@ export default function BottomSheetPanel({
   }, []);
   console.count('BottomSheetPanel render');
 
-  useEffect(() => {
-    if (!sheetRef.current) return;
-    if (sheetIndex === localIndex) return;
-    try { sheetRef.current.snapToIndex(sheetIndex); } catch {}
-    setLocalIndex(sheetIndex);
-  }, [sheetIndex, localIndex]);
-
   const handleSheetChange = useCallback(
     (index) => {
-      setLocalIndex(index);
       try { Haptics.selectionAsync(); } catch {}
-      if (index !== sheetIndex) {
-        onSheetIndexChange?.(index);
-      }
+      onSheetIndexChange?.(index);
     },
-    [onSheetIndexChange, sheetIndex]
+    [onSheetIndexChange]
   );
 
   const topBarHRef = useRef(-1);


### PR DESCRIPTION
## Summary
- simplify BottomSheetPanel by removing unused local index state
- trigger haptics and external index change directly on sheet updates

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ebf2308d48322b6d3f86909fa9a86